### PR TITLE
FIX: pims error

### DIFF
--- a/xpdsim/__init__.py
+++ b/xpdsim/__init__.py
@@ -3,9 +3,11 @@ import bluesky.examples as be
 
 from xpdsim.build_sim_db import build_sim_db
 from xpdsim.movers import shctl1, cs700
-from xpdsim.dets import SimulatedPE1C
+from xpdsim.dets import *
 
 db = build_sim_db() # default is sqlite
 db.reg.register_handler('RWFS_NPY', be.ReaderWithRegistryHandler)
 simple_pe1c = SimulatedPE1C('pe1c', {'pe1_image':lambda: np.ones((5, 5))},
                             reg=db.reg)
+# advanced detector
+xpd_pe1c = det_factory('pe1c', db.reg, nsls_ii_path, shutter=shctl1)

--- a/xpdsim/dets.py
+++ b/xpdsim/dets.py
@@ -19,9 +19,11 @@ import numpy as np
 import time as ttime
 from cycler import cycler
 from itertools import chain
+from tifffile import imread
 from pims import ImageSequence
 from pkg_resources import resource_filename as rs_fn
 import bluesky.examples as be
+from pathlib import Path
 
 DATA_DIR_STEM = 'xpdsim.data'
 
@@ -118,9 +120,12 @@ def build_image_cycle(path):
     Cycler:
         The iterable like object to cycle through the images
     """
-    imgs = ImageSequence(os.path.join(path, '*.tif*'))
-    return cycler(pe1_image=[i for i in imgs])
+    p = Path(path)
+    imgs = [imread(str(fp)) for fp in p.glob('*.tif*')]
+    # switch back to pims if the error is resolved
+    #imgs = ImageSequence(path)
 
+    return cycler(pe1_image=imgs)
 
 
 def det_factory(name, reg, src_path, shutter=None, **kwargs):
@@ -155,8 +160,8 @@ def det_factory(name, reg, src_path, shutter=None, **kwargs):
             return np.zeros(sample_img.shape)
 
         return SimulatedPE1C(name,
-                             {'pe1_image': lambda: nexter()}, reg=reg,
-                             shutter=shutter,
+                             {'pe1_image': lambda: nexter()},
+                             reg=reg, shutter=shutter,
                              dark_fields={'pe1_image': lambda: dark_nexter()},
                              **kwargs)
 

--- a/xpdsim/tests/test_dets.py
+++ b/xpdsim/tests/test_dets.py
@@ -24,8 +24,11 @@ def test_dets(db, tmp_dir, name, fp):
     cg = cycle2()
     for name, doc in db.restream(db[-1], fill=True):
         if name == 'event':
-            assert_array_equal(doc['data']['pe1_image'],
-                               next(cg)['pe1_image'])
+            db_img = doc['data']['pe1_image']
+            cycler_img = next(cg)['pe1_image']
+            assert_array_equal(db_img, cycler_img)
+            assert db_img.squeeze().shape == (2048, 2048)
+            assert cycler_img.squeeze().shape == (2048, 2048)
     assert uid is not None
 
 


### PR DESCRIPTION
Fixed the error found during the simulation: ``pims.ImageSequence`` does not load image with the proper shape. Replace ``ImageSequence`` with ``tifffile.imread`` for now.