### PR TITLE
MNT: shutter check and sim_db name

### DIFF
--- a/xpdsim/__init__.py
+++ b/xpdsim/__init__.py
@@ -6,7 +6,7 @@ from ophyd.sim import (SynSignalWithRegistry, NumpySeqHandler,
                        SynSignalRO)
 from xpdsim.area_det import det_factory, nsls_ii_path, xpd_wavelength
 
-db_path, db = build_sim_db() # default is sqlite
+sim_db_dir, db = build_sim_db() # default is sqlite
 db.reg.register_handler('NPY_SEQ', NumpySeqHandler)
 # detector with 5 by 5 image -> for testing functionality
 simple_pe1c = det_factory(db.reg)

--- a/xpdsim/area_det.py
+++ b/xpdsim/area_det.py
@@ -88,9 +88,11 @@ def det_factory(reg, *, shutter=None,
             gen = cycle()
             if shutter:
                 status = shutter.get()
-                if status.readback ==  XPD_SHUTTER_CONF['close']:
+                if np.allclose(status.readback,
+                               XPD_SHUTTER_CONF['close']):
                     return np.zeros_like(_img)
-                elif status.readback ==  XPD_SHUTTER_CONF['open']:
+                elif np.allclose(status.readback,
+                                 XPD_SHUTTER_CONF['open']):
                     return next(gen)['pe1_image']
             else:
                 return next(gen)['pe1_image']

--- a/xpdsim/tests/conftest.py
+++ b/xpdsim/tests/conftest.py
@@ -17,12 +17,11 @@ import shutil
 import pytest
 import tempfile
 from bluesky.tests.conftest import RE
-from xpdsim.build_sim_db import build_sim_db
 
 @pytest.fixture(scope='module')
 def db():
-    from xpdsim import db, db_path
+    from xpdsim import db, sim_db_dir
     yield db
-    if os.path.exists(db_path):
+    if os.path.exists(sim_db_dir):
         print('Flush db dir')
-        shutil.rmtree(db_path)
+        shutil.rmtree(sim_db_dir)


### PR DESCRIPTION
1. Use ``np.allclose`` to check shutter readback value, instead of strict equality
2. Standardizing name of simulated db path