### PR TITLE
ENH: let xpdsim use the latest version of databroker and ophyd

### DIFF
--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -1,4 +1,4 @@
 ophyd
 pyfai
-databroker=0.13.0
+databroker
 bluesky

--- a/xpdsim/__init__.py
+++ b/xpdsim/__init__.py
@@ -24,17 +24,15 @@ image_file = rs_fn(
 sim_db_dir, db = build_sim_db()  # default is sqlite
 db.reg.register_handler("NPY_SEQ", NumpySeqHandler)
 # detector with 5 by 5 image -> for testing functionality
-simple_pe1c = det_factory(db.reg)
+simple_pe1c = det_factory()
 # detector with full image -> for testing data reduction
 xpd_pe1c = det_factory(
-    db.reg,
     full_img=True,
     src_path=nsls_ii_path,
     shutter=shctl1,
     noise=np.random.poisson,
 )
 xpd_pe1c_mover = det_factory(
-    db.reg,
     full_img=True,
     src_path=nsls_ii_path,
     shutter=shctl1,
@@ -42,7 +40,6 @@ xpd_pe1c_mover = det_factory(
     mover=cs700
 )
 xpd_pe2c = det_factory(
-    db.reg,
     full_img=True,
     src_path=nsls_ii_path,
     shutter=shctl1,

--- a/xpdsim/area_det.py
+++ b/xpdsim/area_det.py
@@ -57,21 +57,13 @@ class SimulatedCam(Device):
     acquire = sim.SynSignal(name="acquire")
 
 
-def det_factory(
-    reg, *, shutter=None, src_path=None, noise=None, name="pe1_image",
-        mover=None, **kwargs
-):
+def det_factory(*, shutter=None, src_path=None, noise=None, name="pe1_image", mover=None, **kwargs):
     """Build a detector using real images
 
     Parameters
     ----------
-    reg: Registry
-        The filestore to save all the data in
     src_path: str
         The path to the source tiff files
-    full_img : bool, keyword-only
-        Option on if want to return full size imag.
-        Deafult is False.
 
     Returns
     -------
@@ -102,14 +94,12 @@ def det_factory(
         det = sim.SynSignalWithRegistry(
             name=name,
             func=lambda: nexter(shutter),
-            reg=reg,
             save_path=mkdtemp(prefix="xpdsim"),
         )
     else:
         det = sim.SynSignalWithRegistry(
             name=name,
             func=lambda: np.ones((5, 5)),
-            reg=reg,
             save_path=mkdtemp(prefix="xpdsim"),
         )
     # plug-ins
@@ -165,7 +155,6 @@ def det_factory_dexela(
     det = sim.SynSignalWithRegistry(
         name=name,
         func=lambda: nexter(shutter),
-        reg=reg,
         save_path=mkdtemp(prefix="xpdsim"),
     )
     # plug-ins
@@ -224,7 +213,6 @@ def det_factory_blackfly(
     det = sim.SynSignalWithRegistry(
         name=name,
         func=lambda: nexter(shutter),
-        reg=reg,
         save_path=mkdtemp(prefix="xpdsim"),
     )
     # plug-ins

--- a/xpdsim/movers.py
+++ b/xpdsim/movers.py
@@ -1,4 +1,5 @@
-from ophyd.sim import SynAxis, SynSignal, Device, Component
+from ophyd.sim import SynAxis, SynSignal, Device
+from ophyd import Component
 
 cs700 = SynAxis(name='cs700', value=300.)
 cs700.readback.name = 'temperature'

--- a/xpdsim/tests/test_dets.py
+++ b/xpdsim/tests/test_dets.py
@@ -32,7 +32,7 @@ def test_img_shape(name, fp):
 
 @pytest.mark.parametrize(("name", "fp"), test_params)
 def test_dets(RE, db, fp, name):
-    det = det_factory(db.reg, src_path=fp)
+    det = det_factory(src_path=fp)
     RE.subscribe(db.insert, "all")
     uid = RE(bp.count([det]))
     cycle2 = build_image_cycle(fp)
@@ -49,7 +49,7 @@ def test_dets(RE, db, fp, name):
 
 @pytest.mark.parametrize(("name", "fp"), test_params)
 def test_dets_shutter(RE, db, name, fp):
-    det = det_factory(db.reg, src_path=fp, shutter=shctl1)
+    det = det_factory(src_path=fp, shutter=shctl1)
     RE.subscribe(db.insert, "all")
     cycle2 = build_image_cycle(fp)
     cg = cycle2()
@@ -77,7 +77,7 @@ def test_dets_shutter(RE, db, name, fp):
 @pytest.mark.parametrize(("name", "fp"), test_params)
 def test_dets_noise(RE, db, name, fp):
     det = det_factory(
-        db.reg, src_path=fp, shutter=shctl1, noise=np.random.poisson
+        src_path=fp, shutter=shctl1, noise=np.random.poisson
     )
     RE.subscribe(db.insert, "all")
     cycle2 = build_image_cycle(fp)


### PR DESCRIPTION
Hi @sbillinge @chiahaoliu . I update the xpdsim so that it can use the latests verions of databroker and ophyd. Please review myedits. I plan to clean the four issues we have now and make a release of v0.4.1. 

This is important because xpdsim is a dependency of xpdan. Xpdan uses the latest databroker and ophyd but this one doesn't. I am worried about this inconsistency will cause errors after we installed it from nsls-ii-forge.